### PR TITLE
add store latitude and longitude for az maps and track origin

### DIFF
--- a/accounting-service/src/main/java/com/microsoft/gbb/rasa/accountingservice/dto/OrderSummaryDto.java
+++ b/accounting-service/src/main/java/com/microsoft/gbb/rasa/accountingservice/dto/OrderSummaryDto.java
@@ -19,7 +19,7 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Container(containerName="reddog", ru="400")
+@Container(containerName="reddog11", ru="400")
 public class OrderSummaryDto extends AbstractDto<String> {
 
     @JsonProperty("orderCompletedDate")
@@ -54,6 +54,15 @@ public class OrderSummaryDto extends AbstractDto<String> {
 
     @JsonProperty("orderTotal")
     private double orderTotal;
+
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
 
     @Override
     public String toString() {

--- a/accounting-service/src/main/java/com/microsoft/gbb/rasa/accountingservice/model/OrderSummary.java
+++ b/accounting-service/src/main/java/com/microsoft/gbb/rasa/accountingservice/model/OrderSummary.java
@@ -43,6 +43,15 @@ public class OrderSummary {
     @JsonProperty("orderTotal")
     private double orderTotal;
 
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
+
     @Override
     public String toString() {
         return "OrderSummary{" +

--- a/loyalty-service/src/main/java/com/microsoft/gbb/reddog/loyaltyservice/dto/OrderSummaryDto.java
+++ b/loyalty-service/src/main/java/com/microsoft/gbb/reddog/loyaltyservice/dto/OrderSummaryDto.java
@@ -49,6 +49,15 @@ public class OrderSummaryDto extends AbstractDto<String> {
     @JsonProperty("orderTotal")
     private double orderTotal;
 
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
+
     @Override
     public String toString() {
         return "OrderSummaryDto{" +

--- a/loyalty-service/src/main/java/com/microsoft/gbb/reddog/loyaltyservice/model/LoyaltySummary.java
+++ b/loyalty-service/src/main/java/com/microsoft/gbb/reddog/loyaltyservice/model/LoyaltySummary.java
@@ -30,6 +30,15 @@ public class LoyaltySummary {
     @JsonProperty("pointTotal")
     private int pointTotal;
 
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
+
     @Override
     public String toString() {
         return "LoyaltySummary{" +

--- a/loyalty-service/src/main/java/com/microsoft/gbb/reddog/loyaltyservice/model/OrderSummary.java
+++ b/loyalty-service/src/main/java/com/microsoft/gbb/reddog/loyaltyservice/model/OrderSummary.java
@@ -43,6 +43,15 @@ public class OrderSummary {
     @JsonProperty("orderTotal")
     private double orderTotal;
 
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
+
     @Override
     public String toString() {
         return "OrderSummary{" +

--- a/makeline-service/src/main/java/com/microsoft/gbb/rasa/makelineservice/dto/OrderSummaryDto.java
+++ b/makeline-service/src/main/java/com/microsoft/gbb/rasa/makelineservice/dto/OrderSummaryDto.java
@@ -20,7 +20,7 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Container(containerName="reddog", ru="400")
+@Container(containerName="reddog11", ru="400")
 public class OrderSummaryDto extends AbstractDto<String> {
 
     @JsonProperty("orderCompletedDate")
@@ -55,6 +55,15 @@ public class OrderSummaryDto extends AbstractDto<String> {
 
     @JsonProperty("orderTotal")
     private double orderTotal;
+
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
 
     @Override
     public String toString() {

--- a/makeline-service/src/main/java/com/microsoft/gbb/rasa/makelineservice/model/OrderSummary.java
+++ b/makeline-service/src/main/java/com/microsoft/gbb/rasa/makelineservice/model/OrderSummary.java
@@ -43,6 +43,15 @@ public class OrderSummary {
     @JsonProperty("orderTotal")
     private double orderTotal;
 
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
+
     @Override
     public String toString() {
         return "OrderSummary{" +

--- a/order-service/src/main/java/com/microsoft/gbb/rasa/orderservice/dto/CustomerOrderDto.java
+++ b/order-service/src/main/java/com/microsoft/gbb/rasa/orderservice/dto/CustomerOrderDto.java
@@ -28,6 +28,15 @@ public class CustomerOrderDto extends AbstractDto<String> {
     @JsonProperty("storeId")
     private String storeId;
 
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
+
     @JsonProperty("orderItems")
     private List<CustomerOrderItemDto> orderItems;
 

--- a/order-service/src/main/java/com/microsoft/gbb/rasa/orderservice/dto/OrderSummaryDto.java
+++ b/order-service/src/main/java/com/microsoft/gbb/rasa/orderservice/dto/OrderSummaryDto.java
@@ -49,6 +49,15 @@ public class OrderSummaryDto extends AbstractDto<String> {
     @JsonProperty("orderTotal")
     private double orderTotal;
 
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
+
     @Override
     public String toString() {
         return "OrderSummaryDto{" +

--- a/order-service/src/main/java/com/microsoft/gbb/rasa/orderservice/entities/CustomerOrder.java
+++ b/order-service/src/main/java/com/microsoft/gbb/rasa/orderservice/entities/CustomerOrder.java
@@ -1,5 +1,6 @@
 package com.microsoft.gbb.rasa.orderservice.entities;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -30,6 +31,15 @@ public class CustomerOrder {
 
     @Column(name = "store_id")
     private String storeId;
+
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
 
     @OneToMany(mappedBy = "customerOrder", cascade = CascadeType.ALL, orphanRemoval = true)
     @ToString.Exclude

--- a/order-service/src/main/java/com/microsoft/gbb/rasa/orderservice/entities/OrderSummary.java
+++ b/order-service/src/main/java/com/microsoft/gbb/rasa/orderservice/entities/OrderSummary.java
@@ -1,5 +1,6 @@
 package com.microsoft.gbb.rasa.orderservice.entities;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import javax.persistence.*;
@@ -43,6 +44,15 @@ public class OrderSummary {
 
     @Column(name = "order_total", nullable = false)
     private double orderTotal;
+
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
 
     @OneToMany(mappedBy = "orderSummary", orphanRemoval = true)
     @ToString.Exclude

--- a/receipt-generation-service/src/main/java/com/microsoft/gbb/reddog/receiptgenerationservice/dto/OrderSummaryDto.java
+++ b/receipt-generation-service/src/main/java/com/microsoft/gbb/reddog/receiptgenerationservice/dto/OrderSummaryDto.java
@@ -49,6 +49,15 @@ public class OrderSummaryDto extends AbstractDto<String> {
     @JsonProperty("orderTotal")
     private double orderTotal;
 
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
+
     @Override
     public String toString() {
         return "OrderSummaryDto{" +

--- a/receipt-generation-service/src/main/java/com/microsoft/gbb/reddog/receiptgenerationservice/model/OrderSummary.java
+++ b/receipt-generation-service/src/main/java/com/microsoft/gbb/reddog/receiptgenerationservice/model/OrderSummary.java
@@ -45,6 +45,15 @@ public class OrderSummary {
     @JsonProperty("orderTotal")
     private double orderTotal;
 
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
+
     @Override
     public String toString() {
         return "OrderSummary{" +

--- a/virtual-customers/src/main/java/com/microsoft/gbb/reddog/virtualcustomers/controller/VirtualCustomersController.java
+++ b/virtual-customers/src/main/java/com/microsoft/gbb/reddog/virtualcustomers/controller/VirtualCustomersController.java
@@ -26,12 +26,12 @@ public class VirtualCustomersController {
     @CrossOrigin(origins = "*")
     public ResponseEntity<List<CustomerOrder>> createOrderJob(
             @RequestParam(value = "numOrders", defaultValue = "1") int numOrders,
-            @RequestHeader(value="x-source", required = false) String origin) {
+            @RequestHeader(value="x-origin", required = false) String origin) {
         if (numOrders < 1) {
             return ResponseEntity.badRequest().build();
         }
         log.info("Creating {} orders from {}", numOrders, origin);
-        List<CustomerOrder> orders = orderCreationJobService.createOrders(numOrders);
+        List<CustomerOrder> orders = orderCreationJobService.createOrders(numOrders, origin);
         jobScheduler.enqueue(orderCreationJobService::execute);
         return ResponseEntity.ok(orders);
     }

--- a/virtual-customers/src/main/java/com/microsoft/gbb/reddog/virtualcustomers/model/CustomerOrder.java
+++ b/virtual-customers/src/main/java/com/microsoft/gbb/reddog/virtualcustomers/model/CustomerOrder.java
@@ -30,6 +30,15 @@ public class CustomerOrder {
     @JsonProperty("storeId")
     private String storeId;
 
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
+
     @Override
     public String toString() {
         return "CustomerOrder{" +

--- a/virtual-customers/src/main/java/com/microsoft/gbb/reddog/virtualcustomers/service/OrderCreationJobService.java
+++ b/virtual-customers/src/main/java/com/microsoft/gbb/reddog/virtualcustomers/service/OrderCreationJobService.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 @Component
 public class OrderCreationJobService {
 
+    public static final String ORIGIN = "jobrunr";
     @Value("${data.ORDER_SVC_URL}")
     private String orderServiceUrl;
 
@@ -56,11 +57,11 @@ public class OrderCreationJobService {
             log.info("No products to generate orders for. Exiting.");
             return;
         }
-        CustomerOrder customerOrder = createCustomerOrder(products);
+        CustomerOrder customerOrder = createCustomerOrder(products, ORIGIN);
         log.info("Created order: {}", customerOrder);
     }
 
-    public List<CustomerOrder> createOrders(int numOrders) {
+    public List<CustomerOrder> createOrders(int numOrders, String origin) {
         List<CustomerOrder> orders = new ArrayList<>();
         List<Product> products = getProducts();
         if (products.isEmpty()) {
@@ -68,18 +69,21 @@ public class OrderCreationJobService {
             return orders;
         }
         for (int i = 0; i < numOrders; i++) {
-            orders.add(createCustomerOrder(products));
+            orders.add(createCustomerOrder(products, origin));
         }
         return orders;
     }
 
-    private CustomerOrder createCustomerOrder(List<Product> products) {
+    private CustomerOrder createCustomerOrder(List<Product> products, String origin) {
         CustomerOrder order = CustomerOrder.builder()
                 .storeId(customerGenerator.generateStoreId())
                 .firstName(customerGenerator.generateFirstName())
                 .lastName(customerGenerator.generateLastName())
                 .loyaltyId(String.valueOf(customerGenerator.generateLoyaltyId()))
                 .orderItems(customerGenerator.generateOrderItems(products))
+                .storeLatitude(customerGenerator.generateLatitude())
+                .storeLongitude(customerGenerator.generateLongitude())
+                .origin(origin)
                 .build();
         ObjectMapper mapper = new ObjectMapper();
         mapper.enable(SerializationFeature.WRAP_ROOT_VALUE);

--- a/virtual-customers/src/main/java/com/microsoft/gbb/reddog/virtualcustomers/util/CustomerGenerator.java
+++ b/virtual-customers/src/main/java/com/microsoft/gbb/reddog/virtualcustomers/util/CustomerGenerator.java
@@ -33,6 +33,14 @@ public class CustomerGenerator {
         return faker.number().numberBetween(1, Math.min(totalNumOfProducts, MAX_UNIQUE_ITEMS_PER_ORDER));
     }
 
+    public String generateLatitude() {
+        return String.valueOf(faker.address().latitude());
+    }
+
+    public String generateLongitude() {
+        return String.valueOf(faker.address().longitude());
+    }
+
     public String generateStoreId() {
         return faker.gameOfThrones().city();
     }

--- a/virtual-worker/src/main/java/com/microsoft/gbb/reddog/virtualworker/dto/OrderSummaryDto.java
+++ b/virtual-worker/src/main/java/com/microsoft/gbb/reddog/virtualworker/dto/OrderSummaryDto.java
@@ -49,6 +49,15 @@ public class OrderSummaryDto extends AbstractDto<String> {
     @JsonProperty("orderTotal")
     private double orderTotal;
 
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
+
     @Override
     public String toString() {
         return "OrderSummaryDto{" +

--- a/virtual-worker/src/main/java/com/microsoft/gbb/reddog/virtualworker/model/OrderSummary.java
+++ b/virtual-worker/src/main/java/com/microsoft/gbb/reddog/virtualworker/model/OrderSummary.java
@@ -43,6 +43,15 @@ public class OrderSummary {
     @JsonProperty("orderTotal")
     private double orderTotal;
 
+    @JsonProperty("origin")
+    private String origin;
+
+    @JsonProperty("storeLatitude")
+    private String storeLatitude;
+
+    @JsonProperty("storeLongitude")
+    private String storeLongitude;
+
     @Override
     public String toString() {
         return "OrderSummary{" +


### PR DESCRIPTION
- Add `storeLatitude` and `storeLongitude` to track store locations, including fake lat/long, for Azure maps, as suggested by @jschluchter 
- Track request origin with a custom header