### PR TITLE
Use the reddog-spring groupId instead

### DIFF
--- a/accounting-service/pom.xml
+++ b/accounting-service/pom.xml
@@ -8,7 +8,7 @@
         <version>2.7.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
-    <groupId>com.microsoft.gbb.reddog</groupId>
+    <groupId>com.microsoft.gbb.reddog-spring</groupId>
     <artifactId>accounting-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>accounting-service</name>

--- a/ancillary/local-config-service/pom.xml
+++ b/ancillary/local-config-service/pom.xml
@@ -8,7 +8,7 @@
 		<version>2.7.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>com.microsoft.gbb.reddog</groupId>
+	<groupId>com.microsoft.gbb.reddog-spring</groupId>
 	<artifactId>local-config-service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>local-config-service</name>

--- a/ancillary/local-eureka-server/pom.xml
+++ b/ancillary/local-eureka-server/pom.xml
@@ -8,7 +8,7 @@
 		<version>2.7.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>com.microsoft.gbb.reddog</groupId>
+	<groupId>com.microsoft.gbb.reddog-spring</groupId>
 	<artifactId>local-eureka-server</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>local-eureka-server</name>

--- a/ancillary/local-gateway/pom.xml
+++ b/ancillary/local-gateway/pom.xml
@@ -8,7 +8,7 @@
         <version>2.7.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
-    <groupId>com.microsoft.gbb.reddog</groupId>
+    <groupId>com.microsoft.gbb.reddog-spring</groupId>
     <artifactId>local-gateway</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>local-gateway</name>

--- a/loyalty-service/pom.xml
+++ b/loyalty-service/pom.xml
@@ -8,7 +8,7 @@
         <version>2.7.2-SNAPSHOT</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
-    <groupId>com.microsoft.gbb.reddog</groupId>
+    <groupId>com.microsoft.gbb.reddog-spring</groupId>
     <artifactId>loyalty-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>loyalty-service</name>

--- a/makeline-service/pom.xml
+++ b/makeline-service/pom.xml
@@ -8,7 +8,7 @@
         <version>2.7.2-SNAPSHOT</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
-    <groupId>com.microsoft.gbb.reddog</groupId>
+    <groupId>com.microsoft.gbb.reddog-spring</groupId>
     <artifactId>makeline-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>makeline-service</name>

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -8,7 +8,7 @@
         <version>2.7.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
-    <groupId>com.microsoft.gbb.reddog</groupId>
+    <groupId>com.microsoft.gbb.reddog-spring</groupId>
     <artifactId>order-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>order-service</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.gbb</groupId>
-    <artifactId>reddog</artifactId>
+    <artifactId>reddog-spring</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>reddog</name>
     <packaging>pom</packaging>

--- a/receipt-generation-service/pom.xml
+++ b/receipt-generation-service/pom.xml
@@ -8,7 +8,7 @@
         <version>2.7.2-SNAPSHOT</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
-    <groupId>com.microsoft.gbb.reddog</groupId>
+    <groupId>com.microsoft.gbb.reddog-spring</groupId>
     <artifactId>receipt-generation-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>receipt-generation-service</name>

--- a/virtual-customers/pom.xml
+++ b/virtual-customers/pom.xml
@@ -8,7 +8,7 @@
         <version>2.7.2-SNAPSHOT</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
-    <groupId>com.microsoft.gbb.reddog</groupId>
+    <groupId>com.microsoft.gbb.reddog-spring</groupId>
     <artifactId>virtual-customers</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>virtual-customers</name>

--- a/virtual-worker/pom.xml
+++ b/virtual-worker/pom.xml
@@ -8,7 +8,7 @@
         <version>2.7.2-SNAPSHOT</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
-    <groupId>com.microsoft.gbb.reddog</groupId>
+    <groupId>com.microsoft.gbb.reddog-spring</groupId>
     <artifactId>virtual-worker</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>virtual-worker</name>


### PR DESCRIPTION
Because we now have a Quarkus version of the RedDog (and maybe one day other technologies) wouldn't it be better to have a different groupId? `reddog-spring` groupId instead of just `reddog` (and this way we could have `reddog-quarkus`, etc.)