### PR TITLE
Fix breaking change with order-service

### DIFF
--- a/order-service/src/main/java/com/microsoft/gbb/reddog/orderservice/entity/OrderSummary.java
+++ b/order-service/src/main/java/com/microsoft/gbb/reddog/orderservice/entity/OrderSummary.java
@@ -22,8 +22,7 @@ public class OrderSummary {
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "order_id", nullable = false)
     private Long orderId;
-
-    @Temporal(TemporalType.DATE)
+    
     @Column(name = "order_completed_date")
     private LocalDate orderCompletedDate;
 
@@ -38,8 +37,8 @@ public class OrderSummary {
 
     @Column(name = "store_id")
     private String storeId;
-
-    @Temporal(TemporalType.DATE)
+    
+    
     @Column(name = "order_date")
     private LocalDateTime orderDate;
 


### PR DESCRIPTION
- After migrating to java time libraries from java.util.date, there was a breaking side-effect with the usage of `@Temporal` annotation from Hibernate. This is no longer needed, and it should fix order-service issue